### PR TITLE
Stop loading full usermeta to Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this plugin will be documented in this file.
 
 ## Unreleased
 
+- Performance: Stop loading full usermeta (`all_with_meta`) during search results; fetch only core user fields and batch-load just `billing_first_name`, `billing_last_name`, and `billing_email`.
+
 ### Changed
 - Optimized `search_customers()` to avoid N+1 queries by batching user meta loads and fetching order counts + recent orders in aggregated queries.
 - Added batch helpers for order counts (HPOS + legacy fallback) and recent orders per customer.
@@ -12,6 +14,7 @@ All notable changes to this plugin will be documented in this file.
 ### Added
 - Sticky admin toolbar search input that redirects to the KISS Search admin page with a `q` parameter.
 - Auto-run search on the KISS Search page when opened with `?q=...`.
+- Debug logging for customer searches (enabled by default; disable via `KISS_WOO_COS_DEBUG`).
 
 ### Fixed
 - Floating toolbar bootstrap timing so it reliably appears when the plugin is active.


### PR DESCRIPTION
Stop loading full usermeta (`all_with_meta`) during search results; fetch only core user fields and batch-load just `billing_first_name`, `billing_last_name`, and `billing_email`.