### PR TITLE
WP Toolbar Floating issues esp. Gutenberg behavior -> Development

### DIFF
--- a/4X4.md
+++ b/4X4.md
@@ -1,7 +1,7 @@
 ---
 client: kissplugins
 repo: https://github.com/kissplugins/KISS-woo-fast-search
-last_edit: 2026-03-05
+last_edit: 2026-03-06
 week_of: 2026-03-02
 source_pr_number: 46
 sprint: coupon-search-merge
@@ -14,7 +14,7 @@ Pro-tip: Ask your VS Code AI to "self populate" above.
 A simple, actionable framework to prioritize and track engineering tasks. Focus on alignment, transparency, continuous improvement, and increasing clarity for everyone. This document does not replace your project management tools. It is meant to be a simple, actionable checklist to help you focus on the most important tasks for the week.
 
 # About the Current Project
-KISS Woo Fast Search (v1.2.16) — A WooCommerce admin plugin for fast customer, order, and coupon search. Currently on `development` branch preparing PR #46 (Coupon Search) for merge to `main`. All blocking issues resolved; two backlog items remain.
+KISS Woo Fast Search (v1.2.18) — A WooCommerce admin plugin for fast customer, order, and coupon search. Currently on `development` branch preparing PR #46 (Coupon Search) for merge to `main`. All blocking issues resolved; two backlog items remain.
 
 ---
 
@@ -34,6 +34,16 @@ KISS Woo Fast Search (v1.2.16) — A WooCommerce admin plugin for fast customer,
 
 > **Tip:** If your team frequently handles urgent issues, consider reserving 1-2 slots for hotfixes. Otherwise, use all 4 slots for planned work.
 
+- [x] Fix toolbar z-index and content push-down — Rewrote CSS stacking (`9997→99998`), direct `#wpcontent`/`#adminmenuwrap` push with CSS vars, added Gutenberg editor support (v1.2.17)
+- [x] Fix early `current_user_can()` + scoped CSS + Gutenberg double-offset — Moved capability check out of `plugins_loaded` bootstrap, scoped `!important` rules under `body.kiss-toolbar-active`, reset editor page margins (v1.2.18)
+- [x] Fix wrong debug constant + gate verbose logging — `KISS_WOO_DEBUG` → `KISS_WOO_FAST_SEARCH_DEBUG`, wrapped 10 `error_log()` calls behind debug flag (v1.2.12)
+- [x] Fix benchmark page PII — Changed hardcoded personal email to `devops@neochro.me` (v1.2.13)
+
+---
+
+## 3. Previous Week
+**Review completed, deferred, or blocked tasks from the prior week.**
+
 - [x] Merge feature/add-coupon-search into development — Resolved conflicts, unified debug logging (v1.2.14)
 - [x] Fix N+1 fallback query — Replaced per-coupon `WC_Coupon` loop with 2 batch SQL queries (v1.2.15)
 - [x] Remove debug files + hardcoded test values — Deleted scratch files, added `.gitignore` patterns (v1.2.16)
@@ -41,23 +51,13 @@ KISS Woo Fast Search (v1.2.16) — A WooCommerce admin plugin for fast customer,
 
 ---
 
-## 3. Previous Week
-**Review completed, deferred, or blocked tasks from the prior week.**
-
-- [x] FULLTEXT index + BOOLEAN MODE search — Replaced `LIKE '%term%'` with `MATCH AGAINST` on coupon lookup table (v1.2.7)
-- [x] Replace unconditional error_log() — 7 calls converted to `KISS_Woo_Debug_Tracer::log()` (v1.2.8)
-- [x] Remove dead debug_log/is_debug_enabled methods — 9 call sites converted to centralized tracer (v1.2.8)
-- [x] Fix esc_like for FULLTEXT — Replaced `$wpdb->esc_like()` with FULLTEXT boolean operator stripping (v1.2.8)
-
----
-
 ## 4. Recent Lessons Learned
 **Capture insights to improve processes and avoid repeating mistakes.**
 
-1. **FULLTEXT > LIKE for multi-column search**: `OR title LIKE '%term%'` forces MySQL to abandon ALL indexes. FULLTEXT with BOOLEAN MODE gives sub-ms search on 360k+ rows.
-2. **Always verify CHANGELOG claims against code**: v1.2.8 claimed error_log removal complete but 7 calls remained; v1.2.2 claimed debug_log removal but 9 call sites persisted.
-3. **N+1 queries hide behind "temporary" fallback paths**: The `new WC_Coupon()` loop was "only for fresh installs" but was the hot path until backfill completed. Batch loading is always worth the effort.
-4. **`$wpdb->esc_like()` is wrong for FULLTEXT**: It escapes `%` and `_` (LIKE operators), not `+`, `-`, `~`, `<`, `>` (FULLTEXT boolean operators). Different query types need different sanitization.
+1. **CSS z-index must respect WP admin stacking**: WP admin bar is `99999`; custom toolbars should use `99998`. Never rely solely on JS body classes for layout displacement — use direct CSS selectors with `!important` on `#wpcontent` and `#adminmenuwrap`.
+2. **Debug constants must be consistent across all endpoints**: Using different constant names (`KISS_WOO_DEBUG` vs `KISS_WOO_FAST_SEARCH_DEBUG`) silently breaks debugging for some AJAX handlers. Grep for all debug constant references before shipping.
+3. **Gate all verbose logging behind debug flags**: Unconditional `error_log()` calls create noisy production logs and potential info disclosure. Always wrap in `if ( defined('CONSTANT') && CONSTANT )`.
+4. **Never ship real PII as defaults**: Hardcoded personal emails in benchmark/test pages are a liability. Use team/role-based addresses (`devops@...`) or empty defaults with placeholder text.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.18] - 2026-03-06
+
+### Fixed
+- **CRITICAL: `current_user_can()` called too early at `plugins_loaded`** — Toolbar bootstrap (`toolbar.php:202`) called `current_user_can('manage_woocommerce')` at file-include time during `plugins_loaded`, before WordPress initializes the user session (which happens at `init`). This could cause the toolbar to silently fail to load for legitimate users.
+  - **Fix**: Removed capability check from bootstrap; only `is_admin()` is checked at include time. All three callback methods (`enqueue_assets`, `render_toolbar`, `add_toolbar_body_class`) already gate on `current_user_can('manage_woocommerce')` and fire on later hooks where the user session is available.
+
+- **HIGH: Unscoped `!important` on core WP selectors** — `#wpcontent` and `#adminmenuwrap` margin-top rules used bare global selectors with `!important`, risking conflicts with other plugins/themes.
+  - **Fix**: Scoped rules under `body.kiss-toolbar-active` — a new server-side body class added via `admin_body_class` filter. This provides a kill-switch: if the toolbar class isn't instantiated or the user lacks capability, the body class is absent and layout-push rules don't apply.
+  - **Files Modified**: `toolbar.php` (new `add_toolbar_body_class()` method + filter hook), `admin/css/kiss-woo-toolbar.css`
+
+- **MEDIUM: Potential double-offset on Gutenberg block editor pages** — Both `kiss-woo-toolbar.css` (pushes `#wpcontent` down) and `kiss-woo-toolbar-editor.css` (pushes `.interface-interface-skeleton` down) loaded on editor pages. If the editor layout ever falls back to flow positioning, the toolbar height would be added twice.
+  - **Fix**: `kiss-woo-toolbar-editor.css` now resets `body.kiss-toolbar-active #wpcontent` and `body.kiss-toolbar-active #adminmenuwrap` margin to `0` on block editor pages (this file only loads via `enqueue_block_editor_assets`). The skeleton offset handles editor layout exclusively.
+
+---
+
+## [1.2.17] - 2026-03-06
+
+### Fixed
+- **HIGH: Toolbar z-index and content push-down**: Rewrote toolbar CSS to properly stack below WP admin bar and push admin content down correctly
+  - **Issue**: Toolbar used `z-index: 9997` (too low, got covered by other elements) and relied on a JS-added body class (`.floating-toolbar-active`) for content push-down, which didn't push `#adminmenuwrap` (left sidebar menu)
+  - **Impact**: Toolbar could be covered by other UI elements; admin content and left sidebar overlapped with toolbar
+  - **Solution**: Adopted stacking approach from Neochrome Toolbar reference implementation:
+    - Changed `z-index` from `9997` to `99998` (just below WP admin bar's `99999`)
+    - Added CSS custom properties (`--kiss-toolbar-height`, `--kiss-wp-admin-bar-height`) for maintainable sizing
+    - Changed content push to direct selectors with `!important`: `#wpcontent` and `#adminmenuwrap` both get `margin-top`
+    - Removed dependency on `.floating-toolbar-active` body class for layout
+    - Added `body.is-fullscreen-mode` support for Gutenberg fullscreen
+  - **Files Modified**:
+    - `admin/css/kiss-woo-toolbar.css` — Rewrote positioning, z-index, and content push-down rules
+    - `admin/css/kiss-woo-toolbar-editor.css` — **NEW**: Gutenberg block editor layout overrides
+    - `toolbar.php` — Added `enqueue_block_editor_assets` hook, removed block editor skip logic
+
+### Technical Notes
+- **Z-index Stack**: WP admin bar = `99999`, KISS toolbar = `99998`, media modal = `160000`
+- **CSS Variables**: `--kiss-toolbar-height: 36px` (desktop), `46px` (mobile ≤782px)
+- **Gutenberg Support**: Toolbar now renders in block editor; `.interface-interface-skeleton` offset handles editor layout
+- **Backward Compat**: `floating-toolbar-active` body class still added by JS (harmless) but no longer required for layout
+
+---
+
 ## [1.2.16] - 2026-03-04
 
 ### Removed

--- a/admin/css/kiss-woo-toolbar-editor.css
+++ b/admin/css/kiss-woo-toolbar-editor.css
@@ -1,0 +1,52 @@
+/**
+ * KISS Woo Fast Order Search - Gutenberg Block Editor Overrides
+ *
+ * The block editor has its own layout system. Key selectors:
+ *   .edit-post-header          — the top editor toolbar
+ *   .interface-interface-skeleton__header — newer WP versions
+ *   .editor-styles-wrapper     — the content canvas
+ *   .edit-post-layout          — outer layout wrapper
+ *
+ * Gutenberg fullscreen mode removes #wpadminbar and shifts
+ * everything up. We detect this via body.is-fullscreen-mode.
+ */
+
+/* ----------------------------------------------------------------
+   1. PUSH GUTENBERG LAYOUT DOWN
+
+   The editor's skeleton layout uses position: fixed or sticky
+   headers. We offset them by our toolbar height.
+   ---------------------------------------------------------------- */
+
+/* Modern Gutenberg (WP 6.x+) — interface skeleton */
+.interface-interface-skeleton {
+    top: calc(var(--kiss-wp-admin-bar-height, 32px) + var(--kiss-toolbar-height, 36px)) !important;
+}
+
+/* Fullscreen mode — no admin bar, just our toolbar */
+body.is-fullscreen-mode .interface-interface-skeleton {
+    top: var(--kiss-toolbar-height, 36px) !important;
+}
+
+/* Legacy layout selector (pre-6.3 compat) */
+.edit-post-layout {
+    padding-top: 0; /* reset any existing padding; our offset on skeleton handles it */
+}
+
+/* ----------------------------------------------------------------
+   2. RESET MAIN-CSS CONTENT PUSH ON BLOCK EDITOR PAGES
+
+   kiss-woo-toolbar.css pushes #wpcontent and #adminmenuwrap down via
+   margin-top. The block editor's skeleton is position: fixed and
+   handles its own offset (see rules above). If both apply, content
+   could shift down twice (toolbar height added to both skeleton top
+   AND wpcontent margin).
+
+   Reset the main-CSS push here so only the skeleton offset applies.
+   This file only loads on block editor screens (enqueue_block_editor_assets).
+   ---------------------------------------------------------------- */
+body.kiss-toolbar-active #wpcontent,
+body.kiss-toolbar-active #adminmenuwrap {
+    margin-top: 0 !important;
+}
+

--- a/admin/css/kiss-woo-toolbar.css
+++ b/admin/css/kiss-woo-toolbar.css
@@ -1,15 +1,32 @@
 /**
  * KISS Woo Fast Order Search - Toolbar Styles
- * Extracted from inline styles in toolbar.php
+ *
+ * Z-index stacking context (WP defaults for reference):
+ *   #wpadminbar       = 99999
+ *   .media-modal       = 160000
+ *   .wp-full-overlay   = 500000
+ *
+ * Our toolbar sits BELOW the WP admin bar (#wpadminbar) but ABOVE
+ * the rest of the admin content. We use a fixed position immediately
+ * below the admin bar (32px on desktop, 46px on mobile).
+ *
+ * Height: 36px (our toolbar)
+ * WP admin bar height: 32px desktop / 46px mobile
  */
+
+:root {
+    --kiss-toolbar-height: 36px;
+    --kiss-wp-admin-bar-height: 32px;
+    --kiss-combined-offset: calc(var(--kiss-wp-admin-bar-height) + var(--kiss-toolbar-height));
+}
 
 #floating-search-toolbar {
     position: fixed;
-    top: 32px; /* Directly below WP admin bar */
+    top: var(--kiss-wp-admin-bar-height); /* Directly below WP admin bar */
     left: 0;
     right: 0;
-    z-index: 9997;
-    height: 32px;
+    z-index: 99998; /* Just below #wpadminbar (99999) */
+    height: var(--kiss-toolbar-height);
     background: #1d2327; /* Match WP admin bar */
     border-bottom: 1px solid #333;
     display: flex;
@@ -18,25 +35,46 @@
     box-sizing: border-box;
 }
 
-/* Adjust for smaller admin bar on mobile */
+/* ----------------------------------------------------------------
+   Push admin content down by our toolbar height.
+
+   The WP admin already offsets content for #wpadminbar (32px).
+   We add our toolbar height on top of that.
+
+   #wpcontent and #adminmenuwrap are the main content containers
+   in wp-admin. We push them down with additional margin-top.
+   ---------------------------------------------------------------- */
+
+/* Push main content area down by our toolbar height.
+   Scoped under body.kiss-toolbar-active (added server-side via
+   admin_body_class filter) so we have a kill-switch if conflicts arise. */
+body.kiss-toolbar-active #wpcontent {
+    margin-top: var(--kiss-toolbar-height) !important;
+}
+
+/* Left admin menu: push the entire menu down so it doesn't
+   tuck behind our toolbar */
+body.kiss-toolbar-active #adminmenuwrap {
+    margin-top: var(--kiss-toolbar-height) !important;
+}
+
+/* ----------------------------------------------------------------
+   Mobile: WP admin bar is 46px on < 783px
+   ---------------------------------------------------------------- */
 @media screen and (max-width: 782px) {
+    :root {
+        --kiss-wp-admin-bar-height: 46px;
+        --kiss-toolbar-height: 46px;
+    }
+
     #floating-search-toolbar {
-        top: 46px;
-        height: 46px;
+        top: 46px; /* explicit fallback for browsers without var() in top */
     }
 }
 
-/* Push admin content down to accommodate toolbar */
-.floating-toolbar-active #wpcontent,
-.floating-toolbar-active #wpfooter {
-    margin-top: 32px;
-}
-
-@media screen and (max-width: 782px) {
-    .floating-toolbar-active #wpcontent,
-    .floating-toolbar-active #wpfooter {
-        margin-top: 46px;
-    }
+/* When WP admin bar is hidden (e.g. full-screen Gutenberg) */
+body.is-fullscreen-mode #floating-search-toolbar {
+    top: 0;
 }
 
 /* Toolbar layout */
@@ -179,7 +217,7 @@
     color: rgb(240, 240, 241);
     cursor: pointer;
     font-size: 13px;
-    height: 32px;
+    height: var(--kiss-toolbar-height);
     padding: 0 12px;
     display: flex;
     align-items: center;
@@ -250,7 +288,7 @@
     color:rgb(240, 240, 241);
     cursor: pointer;
     font-size: 13px;
-    height: 32px;
+    height: var(--kiss-toolbar-height);
     padding: 0 12px;
     transition: background 0.1s ease-in-out, color 0.1s ease-in-out;
 }

--- a/kiss-woo-fast-order-search.php
+++ b/kiss-woo-fast-order-search.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: KISS - Faster Customer & Order Search
  * Description: Super-fast customer and WooCommerce order search for support teams. Search by email or name in one simple admin screen.
- * Version: 1.2.16
+ * Version: 1.2.18
  * Author: Vishal Kharche
  * Text Domain: kiss-woo-customer-order-search
  * Requires at least: 6.0
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'KISS_WOO_COS_VERSION' ) ) {
-    define( 'KISS_WOO_COS_VERSION', '1.2.16' );
+    define( 'KISS_WOO_COS_VERSION', '1.2.18' );
 }
 if ( ! defined( 'KISS_WOO_COS_PATH' ) ) {
     define( 'KISS_WOO_COS_PATH', plugin_dir_path( __FILE__ ) );

--- a/toolbar.php
+++ b/toolbar.php
@@ -34,6 +34,12 @@ class KISS_Woo_COS_Floating_Search_Bar {
 
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
         add_action( 'admin_footer', array( $this, 'render_toolbar' ) );
+
+        // Enqueue inside the Gutenberg block editor specifically.
+        add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+
+        // Add body class for CSS scoping (server-side kill-switch for !important rules).
+        add_filter( 'admin_body_class', array( $this, 'add_toolbar_body_class' ) );
     }
 
     /**
@@ -49,32 +55,24 @@ class KISS_Woo_COS_Floating_Search_Bar {
     }
 
     /**
-     * Detect block editor screens where the floating toolbar should not render.
+     * Add body class for CSS scoping.
      *
-     * @return bool
+     * Provides a kill-switch: if the toolbar is disabled or another plugin
+     * conflicts, the body class won't be present and the layout-push rules
+     * won't apply.
+     *
+     * @param string $classes Space-separated list of body classes.
+     * @return string
      */
-    private function is_block_editor_screen(): bool {
-        if ( ! function_exists( 'get_current_screen' ) ) {
-            return false;
+    public function add_toolbar_body_class( string $classes ): string {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            return $classes;
         }
-
-        $screen = get_current_screen();
-        if ( ! $screen ) {
-            return false;
-        }
-
-        if ( method_exists( $screen, 'is_block_editor' ) ) {
-            return (bool) $screen->is_block_editor();
-        }
-
-        return false;
+        return $classes . ' kiss-toolbar-active';
     }
-    
+
     public function enqueue_assets(): void {
         if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
-            return;
-        }
-        if ( $this->is_block_editor_screen() ) {
             return;
         }
 
@@ -109,11 +107,29 @@ class KISS_Woo_COS_Floating_Search_Bar {
         );
     }
 
-    public function render_toolbar(): void {
-        if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+    /**
+     * Enqueue specifically for the block editor (Gutenberg).
+     * This fires after the editor iframe is set up.
+     *
+     * @return void
+     */
+    public function enqueue_block_editor_assets(): void {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
             return;
         }
-        if ( $this->is_block_editor_screen() ) {
+
+        $version = defined( 'KISS_WOO_COS_VERSION' ) ? KISS_WOO_COS_VERSION : '1.0.0';
+
+        wp_enqueue_style(
+            'kiss-woo-toolbar-editor',
+            KISS_WOO_COS_URL . 'admin/css/kiss-woo-toolbar-editor.css',
+            array(),
+            $version
+        );
+    }
+
+    public function render_toolbar(): void {
+        if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
             return;
         }
 
@@ -202,7 +218,10 @@ class KISS_Woo_COS_Floating_Search_Bar {
 }
 
 // Bootstrap immediately when this file is included by the main plugin.
-// This file is loaded during `plugins_loaded`, so hooking `plugins_loaded` here would be too late.
-if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
+// This file is loaded during `plugins_loaded` — do NOT call current_user_can()
+// here because the user session is not yet initialized. Capability checks are
+// handled inside individual methods that fire on later hooks (admin_enqueue_scripts,
+// admin_footer, admin_body_class).
+if ( is_admin() ) {
     new KISS_Woo_COS_Floating_Search_Bar();
 }


### PR DESCRIPTION
## [1.2.18] - 2026-03-06

### Fixed
- **CRITICAL: `current_user_can()` called too early at `plugins_loaded`** — Toolbar bootstrap (`toolbar.php:202`) called `current_user_can('manage_woocommerce')` at file-include time during `plugins_loaded`, before WordPress initializes the user session (which happens at `init`). This could cause the toolbar to silently fail to load for legitimate users.
  - **Fix**: Removed capability check from bootstrap; only `is_admin()` is checked at include time. All three callback methods (`enqueue_assets`, `render_toolbar`, `add_toolbar_body_class`) already gate on `current_user_can('manage_woocommerce')` and fire on later hooks where the user session is available.

- **HIGH: Unscoped `!important` on core WP selectors** — `#wpcontent` and `#adminmenuwrap` margin-top rules used bare global selectors with `!important`, risking conflicts with other plugins/themes.
  - **Fix**: Scoped rules under `body.kiss-toolbar-active` — a new server-side body class added via `admin_body_class` filter. This provides a kill-switch: if the toolbar class isn't instantiated or the user lacks capability, the body class is absent and layout-push rules don't apply.
  - **Files Modified**: `toolbar.php` (new `add_toolbar_body_class()` method + filter hook), `admin/css/kiss-woo-toolbar.css`

- **MEDIUM: Potential double-offset on Gutenberg block editor pages** — Both `kiss-woo-toolbar.css` (pushes `#wpcontent` down) and `kiss-woo-toolbar-editor.css` (pushes `.interface-interface-skeleton` down) loaded on editor pages. If the editor layout ever falls back to flow positioning, the toolbar height would be added twice.
  - **Fix**: `kiss-woo-toolbar-editor.css` now resets `body.kiss-toolbar-active #wpcontent` and `body.kiss-toolbar-active #adminmenuwrap` margin to `0` on block editor pages (this file only loads via `enqueue_block_editor_assets`). The skeleton offset handles editor layout exclusively.

---

## [1.2.17] - 2026-03-06

### Fixed
- **HIGH: Toolbar z-index and content push-down**: Rewrote toolbar CSS to properly stack below WP admin bar and push admin content down correctly
  - **Issue**: Toolbar used `z-index: 9997` (too low, got covered by other elements) and relied on a JS-added body class (`.floating-toolbar-active`) for content push-down, which didn't push `#adminmenuwrap` (left sidebar menu)
  - **Impact**: Toolbar could be covered by other UI elements; admin content and left sidebar overlapped with toolbar
  - **Solution**: Adopted stacking approach from Neochrome Toolbar reference implementation:
    - Changed `z-index` from `9997` to `99998` (just below WP admin bar's `99999`)
    - Added CSS custom properties (`--kiss-toolbar-height`, `--kiss-wp-admin-bar-height`) for maintainable sizing
    - Changed content push to direct selectors with `!important`: `#wpcontent` and `#adminmenuwrap` both get `margin-top`
    - Removed dependency on `.floating-toolbar-active` body class for layout
    - Added `body.is-fullscreen-mode` support for Gutenberg fullscreen
  - **Files Modified**:
    - `admin/css/kiss-woo-toolbar.css` — Rewrote positioning, z-index, and content push-down rules
    - `admin/css/kiss-woo-toolbar-editor.css` — **NEW**: Gutenberg block editor layout overrides
    - `toolbar.php` — Added `enqueue_block_editor_assets` hook, removed block editor skip logic

### Technical Notes
- **Z-index Stack**: WP admin bar = `99999`, KISS toolbar = `99998`, media modal = `160000`
- **CSS Variables**: `--kiss-toolbar-height: 36px` (desktop), `46px` (mobile ≤782px)
- **Gutenberg Support**: Toolbar now renders in block editor; `.interface-interface-skeleton` offset handles editor layout
- **Backward Compat**: `floating-toolbar-active` body class still added by JS (harmless) but no longer required for layout
